### PR TITLE
remove kwargs from super-charging SimWrappersSessions

### DIFF
--- a/osp/wrappers/simams/simams_session.py
+++ b/osp/wrappers/simams/simams_session.py
@@ -16,7 +16,7 @@ class SimamsSession(SimWrapperSession):
         if engine is None:
             PlamsInit()
             self.engine = MultiJob()
-        super().__init__(engine, **kwargs)
+        super().__init__(engine)
 
     def __str__(self):
         """To overwrite the private str method. Not advised, but here it is."""

--- a/osp/wrappers/simzacros/simzacros_session.py
+++ b/osp/wrappers/simzacros/simzacros_session.py
@@ -18,7 +18,7 @@ class SimzacrosSession(SimWrapperSession):
         if engine is None:
             pz.init()
             self.engine = 'Zacros'
-        super().__init__(engine, **kwargs)
+        super().__init__(engine)
 
     def __str__(self):
         """To overwrite the private str method. Not advised, but here it is."""


### PR DESCRIPTION
Kwargs are passed to SimWrapperSession. Those are passing them to WrapperSessions (superclasses), but they do not take kwargs. This is a bug in simphony-osp<4.0. In order to keep the compability with other wrappers, the kwargs in the __init__-functions are kept, but not inherited while supercharging the parent classes.