### PR TITLE
Fix/order of cuds

### DIFF
--- a/examples/ams_energy_landscape_models.py
+++ b/examples/ams_energy_landscape_models.py
@@ -1,6 +1,6 @@
 """Run AMS LandscapeRefinment calculation using ReaxPro ontology."""
 import os
-from osp.core.namespaces import cuba, emmo
+from osp.core.namespaces import cuba, emmo, cuba
 from osp.core.utils import Cuds2dot, pretty_print
 from osp.core.utils import simple_search as search
 from osp.models.ams.energy_landscape_refinement import EnergyLandscapeRefinement
@@ -50,7 +50,7 @@ pretty_print(model.cuds)
 
 with SimamsSession() as sess:
     reaxpro_wrapper = cuba.Wrapper(session=sess)
-    reaxpro_wrapper.add(model.cuds, rel=emmo.hasPart)
+    reaxpro_wrapper.add(model.cuds, rel=cuba.relationship)
     reaxpro_wrapper.session.run()
 #
 ## Post-processing:

--- a/examples/zacros_model_example.py
+++ b/examples/zacros_model_example.py
@@ -5,6 +5,7 @@ import json
 from osp.models.zacros.co_pyzacros import COpyZacrosModel
 from osp.wrappers.simzacros.simzacros_session import SimzacrosSession
 from osp.core.namespaces import emmo, cuba
+from osp.core.utils import import_cuds
 # from osp.core.utils import pretty_print
 
 #path = os.path.join(os.path.dirname(__file__), "Ziff-Gulari-Barshad-model.json")
@@ -17,9 +18,9 @@ with open(path, mode="r+") as file:
 model = COpyZacrosModel(**content)
 # pretty_print(model.cuds)
 
-
 session = SimzacrosSession()
 wrapper = cuba.Wrapper(session=session)
-wrapper.add(model.cuds, rel=emmo.hasPart)
+cuds = import_cuds(model.file, session=session)
+wrapper.add(*cuds, rel=cuba.relationship)
 session.run()
 # print(".json content:", content)

--- a/osp/models/zacros/co_pyzacros.py
+++ b/osp/models/zacros/co_pyzacros.py
@@ -567,6 +567,7 @@ class COpyZacrosModel:
 
         file = tempfile.NamedTemporaryFile(suffix=".ttl")
         export_cuds(session, file.name)
+        self._file = file.name
         try:
             self._uuid = get_upload(file)
         except Exception as error:
@@ -1205,6 +1206,10 @@ class COpyZacrosModel:
     @property
     def cuds(cls):
         return cls._session.load(cls._session.root).first()
+
+    @property
+    def file(cls):
+        return cls._file
 
     class Config:
         """Pydantic Config for COpyZacrosModel"""

--- a/osp/tools/graph_functions.py
+++ b/osp/tools/graph_functions.py
@@ -6,7 +6,7 @@ from osp.core.cuds import Cuds
 from osp.core.ontology.relationship import OntologyRelationship
 from osp.core.utils import simple_search as search
 from osp.tools.io_functions import raise_error
-from osp.core.namespaces import emmo
+from osp.core.namespaces import emmo, cuba
 from osp.core.utils.general import get_relationships_between
 from typing import List
 # from osp.core.utils import pretty_print

--- a/osp/tools/graph_functions.py
+++ b/osp/tools/graph_functions.py
@@ -26,7 +26,7 @@ def graph_wrapper_dependencies(root_cuds_object: Cuds) -> dict:
         search.find_cuds_object(criterion=lambda x:
                                 x.is_a(oclass=emmo.Simulation),
                                 root=root_cuds_object,
-                                rel=emmo.hasPart,
+                                rel=cuba.relationship,
                                 find_all=True,
                                 max_depth=1)
 
@@ -129,7 +129,7 @@ def graph_calculation_dependencies(root_cuds_object: Cuds,
             search.find_cuds_object(criterion=lambda x:
                                     x.oclass in calculations_types,
                                     root=root_cuds_object,
-                                    rel=emmo.hasPart,
+                                    rel=cuba.relationship,
                                     find_all=True,
                                     max_depth=1)
         relationship_list.append(

--- a/osp/tools/mapping_functions.py
+++ b/osp/tools/mapping_functions.py
@@ -14,7 +14,7 @@ from osp.tools.set_functions import AMS_default_setting
 from osp.core.utils import simple_search as search
 from osp.core.ontology.oclass import OntologyClass
 from osp.core.cuds import Cuds
-from osp.core.namespaces import emmo, crystallography
+from osp.core.namespaces import emmo, crystallography, cuba
 from osp.core.utils import pretty_print
 from typing import List
 
@@ -1574,7 +1574,7 @@ def map_results(engine, root_cuds_object: Cuds):
         # in case of several children, outputs will be added in the order of dependencies.
         search_simulation = \
             search.find_cuds_object(criterion=lambda x: x.is_a(oclass=emmo.Simulation),
-                                    root=root_cuds_object, rel=emmo.hasPart, find_all=True,
+                                    root=root_cuds_object, rel=cuba.relationship, find_all=True,
                                     max_depth=1)
 
         if not len(search_simulation):
@@ -1583,7 +1583,7 @@ def map_results(engine, root_cuds_object: Cuds):
             search_calculation = \
                     search.find_cuds_objects_by_oclass(
                                        emmo.Calculation,
-                                       root_cuds_object, rel=emmo.hasPart)
+                                       root_cuds_object, rel=cuba.relationship)
             map_tarball(engine, search_calculation[0])
 
             if map_calculation_type(root_cuds_object) == "WavefunctionOptimization":
@@ -1668,14 +1668,14 @@ def map_results(engine, root_cuds_object: Cuds):
     elif isinstance(engine, pz.ZacrosResults):
         search_calculation = search.find_cuds_objects_by_oclass(
                                    emmo.MesoscopicCalculation, root_cuds_object,
-                                   rel=emmo.hasPart)
+                                   rel=cuba.relationship)
         map_tarball(engine, search_calculation[0])
 
     else:
         raise_error(file=os.path.basename(__file__), function=map_results.__name__,
                     type='NameError',
                     message='Mapping of the results is not implemented for this engine.')
-    return
+
 
 
 def add_AMSenergy_to_object(job: AMSJob, root_cuds_object: Cuds):

--- a/osp/wrappers/simzacros/simzacros_session.py
+++ b/osp/wrappers/simzacros/simzacros_session.py
@@ -1,5 +1,5 @@
 """Describe Zacros Session class."""
-from osp.core.namespaces import emmo, crystallography
+from osp.core.namespaces import emmo, crystallography, cuba
 from osp.core.session import SimWrapperSession
 from osp.core.cuds import Cuds
 from osp.tools.io_functions import raise_error
@@ -71,8 +71,7 @@ class SimzacrosSession(SimWrapperSession):
         search_calculation = \
             search.find_cuds_objects_by_oclass(
                            emmo.MesoscopicCalculation,
-                           root_obj, emmo.hasPart)
-
+                           root_obj, cuba.relationship)
         #  Raise error if two calculations, for some reason, are found:
         if len(search_calculation) > 1:
             raise_error(file=os.path.basename(__file__),


### PR DESCRIPTION
The order of cuds was not properly annotated through the ontology while being produced by the pydantic models. E.g. the order to the reaction pathways in the energy landscape and atoms is random as soon the CUDS are serialized to RDF.

Using relationships such a `emmo.hasSpatialFirst` solves the problem