### PR TITLE
add uuid property for co-pyzacros model

### DIFF
--- a/osp/models/zacros/co_pyzacros.py
+++ b/osp/models/zacros/co_pyzacros.py
@@ -1208,6 +1208,10 @@ class COpyZacrosModel:
         return cls._session.load(cls._session.root).first()
 
     @property
+    def uuid(cls):
+        return cls._uuid
+
+    @property
     def file(cls):
         return cls._file
 


### PR DESCRIPTION
The uuid-property of the pydantic models are needed in order to be returned to the platform-api.