### PR TITLE
debug workflow mappings

### DIFF
--- a/osp/models/multiscale/co_pt111_meso.py
+++ b/osp/models/multiscale/co_pt111_meso.py
@@ -487,11 +487,8 @@ class COPt111MesoscaleModel:
     def __post_init_post_parse__(self):
         with CoreSession() as session:
             workflow = emmo.Workflow()
-            workflow.add(self.pes_exploration.cuds, rel=emmo.hasSpatialFirst)
             self.pes_exploration.cuds.add(self.binding_site.cuds, rel=emmo.hasSpatialNext)
-            workflow.add(self.binding_site.cuds, rel=emmo.hasSpatialDirectPart)
             self.binding_site.cuds.add(self.zgb_model.cuds, rel=emmo.hasSpatialNext)
-            workflow.add(self.zgb_model.cuds, rel=emmo.hasSpatialLast)
             for oclass in [
                     emmo.ForceFieldIdentifierString,
                     emmo.Solver,
@@ -504,7 +501,10 @@ class COPt111MesoscaleModel:
                     crystallography.UnitCell
                 ]:
                 input_cuds = self.pes_exploration.cuds.get(oclass=oclass, rel=emmo.hasInput)
-                self.binding_site.cuds.add(input_cuds.pop(), rel=emmo.hasInput)
+            self.binding_site.cuds.add(input_cuds.pop(), rel=emmo.hasInput)
+            workflow.add(self.pes_exploration.cuds, rel=emmo.hasSpatialFirst)
+            workflow.add(self.binding_site.cuds, rel=emmo.hasSpatialDirectPart)
+            workflow.add(self.zgb_model.cuds, rel=emmo.hasSpatialLast)
         file = tempfile.NamedTemporaryFile(suffix=".ttl", delete=False)
         export_cuds(session, file.name)
         self._file = file.name


### PR DESCRIPTION
The order of the semantic mappings for the mesoscale multiscale workflow had to changed in order to take effect in the CoreSession on the Pydantic model.