### PR TITLE
make workflow dir unique

### DIFF
--- a/osp/dictionaries/ams/__init__.py
+++ b/osp/dictionaries/ams/__init__.py
@@ -1,0 +1,1 @@
+__path__: list = __import__("pkgutil").extend_path(__path__, __name__)

--- a/osp/dictionaries/example_data/__init__.py
+++ b/osp/dictionaries/example_data/__init__.py
@@ -1,0 +1,1 @@
+__path__: list = __import__("pkgutil").extend_path(__path__, __name__)

--- a/osp/models/multiscale/__init__.py
+++ b/osp/models/multiscale/__init__.py
@@ -1,0 +1,1 @@
+__path__: list = __import__("pkgutil").extend_path(__path__, __name__)

--- a/osp/models/zacros/__init__.py
+++ b/osp/models/zacros/__init__.py
@@ -1,0 +1,1 @@
+__path__: list = __import__("pkgutil").extend_path(__path__, __name__)

--- a/osp/tools/mapping_functions.py
+++ b/osp/tools/mapping_functions.py
@@ -46,7 +46,8 @@ def map_function(self, root_cuds_object: Cuds, engine=None) -> tuple:
         else:
             plams_molecule = map_PLAMSMolecule(root_cuds_object)
 
-        plams_settings = map_PLAMSSettings(self.workdir, root_cuds_object)
+        path = os.path.join(self.workdir, self.jobname)
+        plams_settings = map_PLAMSSettings(path, root_cuds_object)
 
         return (plams_molecule, plams_settings)
 

--- a/osp/wrappers/simams/simams_session.py
+++ b/osp/wrappers/simams/simams_session.py
@@ -7,6 +7,7 @@ from scm.plams import init as PlamsInit
 from scm.plams import MultiJob, AMSJob
 import tempfile
 import os
+from uuid import uuid4
 # from osp.core.utils import pretty_print
 
 
@@ -17,9 +18,9 @@ class SimamsSession(SimWrapperSession):
         """Initialise SimamsSession."""
         if engine is None:
             path = tempfile.mkdtemp()
-            folder = "plams_workdir"
-            jobname = "plamsjob"
-            PlamsInit(path=path, folder = folder)
+            folder = f"plams-workdir-{uuid4()}"
+            jobname = f"plamsjob-{uuid4()}"
+            PlamsInit(path=path, folder=folder)
             self.workdir = os.path.join(path, folder, jobname)
             self.engine = MultiJob(name=jobname)
         super().__init__(engine)

--- a/osp/wrappers/simams/simams_session.py
+++ b/osp/wrappers/simams/simams_session.py
@@ -3,10 +3,8 @@ from osp.core.session import SimWrapperSession
 from osp.core.cuds import Cuds
 from osp.tools.graph_functions import graph_wrapper_dependencies
 from osp.tools.mapping_functions import map_function, map_results
-from scm.plams import init as PlamsInit
+from scm.plams import init, config
 from scm.plams import MultiJob, AMSJob
-import tempfile
-import os
 from uuid import uuid4
 # from osp.core.utils import pretty_print
 
@@ -17,12 +15,10 @@ class SimamsSession(SimWrapperSession):
     def __init__(self, engine=None, **kwargs):
         """Initialise SimamsSession."""
         if engine is None:
-            path = tempfile.mkdtemp()
-            folder = f"plams-workdir-{uuid4()}"
-            jobname = f"plamsjob-{uuid4()}"
-            PlamsInit(path=path, folder=folder)
-            self.workdir = os.path.join(path, folder, jobname)
-            self.engine = MultiJob(name=jobname)
+            init()
+            self.workdir = config.get("default_jobmanager").workdir
+            self.jobname = str(uuid4())
+            self.engine = MultiJob(name=self.jobname)
         super().__init__(engine)
 
     def __str__(self):

--- a/osp/wrappers/simzacros/simzacros_session.py
+++ b/osp/wrappers/simzacros/simzacros_session.py
@@ -8,8 +8,6 @@ from osp.core.utils import simple_search as search
 from osp.models.utils.general import get_download
 import scm.pyzacros as pz
 import os
-import tempfile
-from uuid import uuid4
 # from osp.core.utils import pretty_print
 
 
@@ -19,11 +17,7 @@ class SimzacrosSession(SimWrapperSession):
     def __init__(self, engine=None, **kwargs):
         """Initialise SimamsSession."""
         if engine is None:
-            path = tempfile.mkdtemp()
-            folder = f"plams-workdir-{uuid4()}"
-            jobname = f"plamsjob-{uuid4()}"
-            self.workdir = os.path.join(path, folder, jobname)            
-            pz.init(path=path, folder=folder)
+            pz.init()
             self.engine = 'Zacros'
         super().__init__(engine)
 

--- a/osp/wrappers/simzacros/simzacros_session.py
+++ b/osp/wrappers/simzacros/simzacros_session.py
@@ -8,6 +8,8 @@ from osp.core.utils import simple_search as search
 from osp.models.utils.general import get_download
 import scm.pyzacros as pz
 import os
+import tempfile
+from uuid import uuid4
 # from osp.core.utils import pretty_print
 
 
@@ -17,7 +19,11 @@ class SimzacrosSession(SimWrapperSession):
     def __init__(self, engine=None, **kwargs):
         """Initialise SimamsSession."""
         if engine is None:
-            pz.init()
+            path = tempfile.mkdtemp()
+            folder = f"plams-workdir-{uuid4()}"
+            jobname = f"plamsjob-{uuid4()}"
+            self.workdir = os.path.join(path, folder, jobname)            
+            pz.init(path=path, folder=folder)
             self.engine = 'Zacros'
         super().__init__(engine)
 


### PR DESCRIPTION
* the uuid from the plams and pyzacros jobs were not unique. Hence If a a wrapper was server through a celery-worker, the environment through plams was not re-initialized after a re-run. This leads to unexpected copying of the previously failed job.